### PR TITLE
Add circleci support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,7 +16,7 @@ include CONTRIBUTING.rst
 include LICENSE
 include README.rst
 
-include tox.ini .travis.yml appveyor.yml
+include tox.ini .travis.yml appveyor.yml circle.yml
 
 exclude testrunner.sh
 global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Overview
     :alt: AppVeyor Build Status
     :target: https://ci.appveyor.com/project/williamgibb/pyFuckery
 
+.. |cricleci| image:: https://circleci.com/gh/williamgibb/pyFuckery.svg?style=svg
+    :alt: CircleCI Build Status
+    :target: https://circleci.com/gh/williamgibb/pyFuckery
+
 .. |requires| image:: https://requires.io/github/williamgibb/pyFuckery/requirements.svg?branch=master
     :alt: Requirements Status
     :target: https://requires.io/github/williamgibb/pyFuckery/requirements/?branch=master

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Overview
     * - docs
       - |docs|
     * - tests
-      - | |travis| |appveyor| |requires|
+      - | |travis| |appveyor| |circleci| |requires|
         | |codecov|
         | |landscape|
     * - package
@@ -29,7 +29,7 @@ Overview
     :alt: AppVeyor Build Status
     :target: https://ci.appveyor.com/project/williamgibb/pyFuckery
 
-.. |cricleci| image:: https://circleci.com/gh/williamgibb/pyFuckery.svg?style=svg
+.. |circleci| image:: https://circleci.com/gh/williamgibb/pyFuckery.svg?style=svg
     :alt: CircleCI Build Status
     :target: https://circleci.com/gh/williamgibb/pyFuckery
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  post:
+    - pyenv global 3.4.6 3.3.6 3.5.3
+dependencies:
+  pre:
+    - python --version
+    - uname -a
+    - pip install tox
+    - virtualenv --version
+    - easy_install --version
+    - pip --version
+    - tox --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 3.4.6 3.3.6 3.5.3
+    - pyenv global 3.4.3 3.3.6 3.5.3
 dependencies:
   pre:
     - python --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 3.4.3 3.3.6 3.5.3
+    - pyenv global 3.4.3 3.3.6 3.5.2
 dependencies:
   pre:
     - python --version


### PR DESCRIPTION
travis isn't the most reliable post AWS outage.  Build on circleCI as well.