### PR TITLE
Fixed a broken badge, and removed a broken badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,15 +49,11 @@ Overview
     :alt: Commits since latest release
     :target: https://github.com/williamgibb/pyFuckery/compare/v0.4.1...master
 
-.. |downloads| image:: https://img.shields.io/pypi/dm/fuckery.svg
-    :alt: PyPI Package monthly downloads
-    :target: https://pypi.python.org/pypi/fuckery
-
 .. |wheel| image:: https://img.shields.io/pypi/wheel/fuckery.svg
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/fuckery
 
-.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/ fuckery.svg
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/fuckery.svg
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/fuckery
 


### PR DESCRIPTION
Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)).